### PR TITLE
Check if Response code. Dispatch error if needed.

### DIFF
--- a/apps/IdentityApp/src/features/credentialsView/operations.ts
+++ b/apps/IdentityApp/src/features/credentialsView/operations.ts
@@ -172,9 +172,15 @@ export const sendRequestToServer = (server: serverInterface, did: string, metada
       fetch(server.endpoint + '/requestCredential', {
         method: 'POST',
         body: JSON.stringify(data),
-      }).then(() => {
-          const hash = keccak256(sdrJwt).toString('hex')
-          console.log(hash)
+      })
+        .then((postResponse: Response) => {
+          if (postResponse.status !== 200) {
+            return postResponse.text().then((errorReason: string) => {
+              dispatch(errorRequestCredential(errorReason));
+            });
+          }
+          const hash = keccak256(sdrJwt).toString('hex');
+
           // Create Credential object:
           const credential: Credential = {
             issuer: {


### PR DESCRIPTION
Check if the response from the issuer server is not 200. If so, get body text and display as error to the user.

This PR is coupled with this one: https://github.com/rsksmart/rif-identity-services/pull/22