### PR TITLE
Restore credentials one at a time 

### DIFF
--- a/apps/IdentityApp/src/config.json
+++ b/apps/IdentityApp/src/config.json
@@ -5,5 +5,5 @@
   "DATA_VAULT_ENDPOINT": "http://ec2-3-131-142-122.us-east-2.compute.amazonaws.com:5102",
   "RSK_NODE": "https://did.testnet.rsk.co:4444",
   "CONVEY_URL": "http://ec2-3-131-142-122.us-east-2.compute.amazonaws.com:5104",
-  "CONVEY_DID": "did:ethr:rsk:testnet:0xff80e2096CbE429A3915ADF0983C66c729059cAB"
+  "CONVEY_DID": "did:ethr:rsk:testnet:0xFF80e2096CBE429A3915Adf0983C66c729059CAB"
 }


### PR DESCRIPTION
The previous restore process was adding all of the restored credentials to the typeorm database at the same time. Since the IDs of credentials are auto-created, all restored credentials were trying to INSERT with an ID of 1. This was causing a silent restore error if multiple credentials were being added to typeorm at the same time.

This code makes it so that only one credential can be added to the database at the same time. Then if there are others, it continues adding them until none are left. 