### PR TITLE
Remove unused imports

### DIFF
--- a/apps/IdentityApp/src/features/settings/components/DeveloperSettingsComponent.tsx
+++ b/apps/IdentityApp/src/features/settings/components/DeveloperSettingsComponent.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import ThemeContext, { ThemeInterface } from '@rsksmart/rif-theme';
 import { multilanguage } from 'redux-multilanguage';
-import { StyleSheet, ScrollView, View, Text, GestureResponderEvent } from 'react-native';
+import { StyleSheet, ScrollView, View, Text } from 'react-native';
 import BackScreenComponent from '../../../Libraries/BackScreen/BackScreenComponent';
 import { EndpointsInterface } from '../reducer';
 import { SquareButton } from '../../../Libraries/Button';

--- a/apps/IdentityApp/src/features/settings/components/SettingsComponent.tsx
+++ b/apps/IdentityApp/src/features/settings/components/SettingsComponent.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import ThemeContext, { ThemeInterface } from '@rsksmart/rif-theme';
 import { multilanguage } from 'redux-multilanguage';
-import { StyleSheet, View, Text, GestureResponderEvent } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 import BackScreenComponent from '../../../Libraries/BackScreen/BackScreenComponent';
 import { SquareButton } from '../../../Libraries/Button';
 import ChangeLangaugeModalContainer from '../../../Libraries/ChangeLanguage/ChangeLangaugeModalContainer';

--- a/apps/W3CVerifier/src/features/operations.ts
+++ b/apps/W3CVerifier/src/features/operations.ts
@@ -5,7 +5,7 @@ import { getResolver } from 'ethr-did-resolver'
 import { verifyPresentation, VerifiedPresentation as W3CVerifiedPresentation } from 'did-jwt-vc'
 import { mapFromPayload, VerifiedPresentation } from '../api';
 import {
-  ISSUER_DID, RPC_URL, DID_REGISTRY_ADDRESS, DEFAULT_VP_EXPIRATION_SECONDS,
+  RPC_URL, DID_REGISTRY_ADDRESS, DEFAULT_VP_EXPIRATION_SECONDS,
   CONVEY_URL, IPFS_GATEWAY,
 } from '../../env.json'
 import { StorageProvider, STORAGE_KEYS } from '../providers';

--- a/apps/W3CVerifier/src/features/scanned-presentations-list/PresentationListComponent.tsx
+++ b/apps/W3CVerifier/src/features/scanned-presentations-list/PresentationListComponent.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import { VerifiedPresentation } from '../../api'
-import { layoutStyles, colors } from '../../styles';
+import { colors } from '../../styles';
 import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 

--- a/apps/W3CVerifier/src/screens/scan-qr/ScanQRComponent.tsx
+++ b/apps/W3CVerifier/src/screens/scan-qr/ScanQRComponent.tsx
@@ -1,14 +1,12 @@
 import React, { useState } from 'react';
 import {
-  Text, View, TextInput, StyleSheet,
+  Text, View, StyleSheet,
 } from 'react-native';
 import { layoutStyles, typeStyles } from '../../styles/';
 import { multilanguage } from 'redux-multilanguage';
-import Button from '../../shared/Button'
 import { RNCamera } from 'react-native-camera';
 import BarcodeMask from 'react-native-barcode-mask';
 import LoadingComponent from '../shared/LoadingComponent';
-import { errorConveyLogin } from 'src/state/localUi/actions';
 
 interface ScanQRProps {
   strings: any;
@@ -26,11 +24,7 @@ const ScanQRComponent: React.FC<ScanQRProps> = ({
   isLoggingInToConvey, isLoggedInToConvey, errorConveyLogin
 }) => {
   const [isScanFinished, setIsScanFinished] = useState(false)
-  const [jwt, setJwt] = useState('')
-
-  const handleChangeJwt = (jwt: string) => setJwt(jwt)
-  
-  const handleVerifyPress = () => handleScan(jwt, navigation)
+  // const [jwt, setJwt] = useState('')
 
   const onBarCodeRead = (scanResult: any) => {
     const { data } = scanResult;
@@ -75,12 +69,12 @@ const ScanQRComponent: React.FC<ScanQRProps> = ({
       {/* <View>
         <Text style={typeStyles.paragraph}>{strings.enter_jwt}</Text>
         <TextInput
-          onChangeText={text => handleChangeJwt(text)}
+          onChangeText={text => setJwt(text)}
           value={jwt}
           editable
         />
       </View>
-      <Button title={strings.verify_jwt} onPress={handleVerifyPress} /> */}
+      <Button title={strings.verify_jwt} onPress={() => handleScan(jwt, navigation)} /> */}
       <RNCamera
         captureAudio={false}
         style={styles.preview}

--- a/apps/W3CVerifier/src/styles/layout.ts
+++ b/apps/W3CVerifier/src/styles/layout.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import colors from './colors';
 
 // editable variables:
 const gutter = 20;


### PR DESCRIPTION
Removed unused imports reported by LGTM. 

- I left shim.js and metro.js files alone. These unused imports will remain.
- I commented one line out in the Verifier that references code that is commented out below it for using the app with an emulator. I removed the "unused" imports in the comment section. I'm not sure about this one.